### PR TITLE
added node-oracle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,13 @@ matrix:
       services:
         - docker
 
+    - env:
+      - SUBFOLDER=node_oracle
+      - REPO=cucloudcollab/node-oracle
+      - TAG=$TRAVIS_COMMIT
+      services:
+        - docker
+
 script:
   - docker build $SUBFOLDER -t $REPO:$TAG -t $REPO:latest
 

--- a/node_oracle/Dockerfile
+++ b/node_oracle/Dockerfile
@@ -1,0 +1,33 @@
+# Pull base image
+FROM alpine:latest
+MAINTAINER Scott Ross <sr523@cornell.edu>
+
+# Add Nodejs
+RUN apk add --update nodejs
+
+# Add AWS to install oracle
+RUN apk -Uuv add groff less python py-pip && \
+    pip install awscli && \
+    apk --purge -v del py-pip && \
+    rm /var/cache/apk/*
+
+#INSTALL LIBAIO1 & UNZIP (NEEDED FOR STRONG-ORACLE)
+RUN apk add --update libaio \
+  && apk add --update unzip
+
+#ADD ORACLE INSTANT CLIENT
+RUN mkdir -p opt/oracle
+RUN aws s3 cp s3://vmit-public/oracle/instantclient-basic-linux.x64-12.1.0.2.0.zip . --no-sign-request
+RUN aws s3 cp s3://vmit-public/oracle/instantclient-sdk-linux.x64-12.1.0.2.0.zip . --no-sign-request
+
+RUN unzip instantclient-basic-linux.x64-12.1.0.2.0.zip -d /opt/oracle \
+  && unzip instantclient-sdk-linux.x64-12.1.0.2.0.zip -d /opt/oracle  \
+  && mv /opt/oracle/instantclient_12_1 /opt/oracle/instantclient \
+  && ln -s /opt/oracle/instantclient/libclntsh.so.12.1 /opt/oracle/instantclient/libclntsh.so \
+  && ln -s /opt/oracle/instantclient/libocci.so.12.1 /opt/oracle/instantclient/libocci.so
+
+## Environment Variables for oracle and node to be happy
+ENV LD_LIBRARY_PATH="/opt/oracle/instantclient"
+ENV OCI_HOME="/opt/oracle/instantclient"
+ENV OCI_LIB_DIR="/opt/oracle/instantclient"
+ENV OCI_INCLUDE_DIR="/opt/oracle/instantclient/sdk/include"

--- a/node_oracle/README.md
+++ b/node_oracle/README.md
@@ -1,0 +1,18 @@
+# Node-Oracle
+
+Docker image to be used for a base to nodejs project ready with Oracle instant
+client binaries.  All necessary environment variables are set and ready for use.
+
+## Usage
+Within Dockerfile:
+
+```
+FROM cucloudcollab/node-oracle
+```
+
+## Versions
+This image pulls from base ubuntu and builds node as of v7 for linux.
+This version of the image includes:
+* Build Essentials
+* nodejs
+* Oracle Instant Client


### PR DESCRIPTION
node_oracle pull request.  Somethings here:
1) this is using alpine as the base image
2) it is pulling oracle instant client from a public s3 bucket instead of the repo
3) it does install the awscli because of #2

this will replace some of the dockerhub node images we are using