### PR TITLE
Add node_puppeteer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,13 @@ matrix:
         - docker
 
     - env:
+      - SUBFOLDER=node_puppeteer
+      - REPO=cucloudcollab/node-puppeteer
+      - TAG=$TRAVIS_COMMIT
+      services:
+        - docker
+
+    - env:
       - SUBFOLDER=oracle_instantclient
       - REPO=cucloudcollab/oracle-instantclient
       - TAG=$TRAVIS_COMMIT

--- a/node_puppeteer/Dockerfile
+++ b/node_puppeteer/Dockerfile
@@ -1,0 +1,36 @@
+# Stolen from official Puppeteer docs
+# https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-in-docker
+
+FROM node:8
+
+# Install latest chrome dev package.
+# Note: this installs the necessary libs to make the bundled version of Chromium that Pupppeteer
+# installs, work.
+RUN apt-get update && apt-get install -y wget --no-install-recommends \
+    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
+    && apt-get update \
+    && apt-get install -y google-chrome-unstable \
+      --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get purge --auto-remove -y curl \
+    && rm -rf /src/*.deb
+
+# Uncomment to skip the chromium download when installing puppeteer. If you do,
+# you'll need to launch puppeteer with:
+#     browser.launch({executablePath: 'google-chrome-unstable'})
+# ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
+
+# Install puppeteer so it's available in the container.
+RUN yarn add puppeteer
+
+# Add pptr user.
+RUN groupadd -r pptruser && useradd -r -g pptruser -G audio,video pptruser \
+    && mkdir -p /home/pptruser/Downloads \
+    && chown -R pptruser:pptruser /home/pptruser \
+    && chown -R pptruser:pptruser /node_modules
+
+# Run user as non privileged.
+USER pptruser
+
+CMD ["google-chrome-unstable"]

--- a/node_puppeteer/README.md
+++ b/node_puppeteer/README.md
@@ -1,0 +1,16 @@
+# Node + Puppeteer
+
+Puppeteer is a NodeJS API grafted onto Chrome Headless.  It's perfect for doing client
+testing - low overhead, small size, and based on the latest Chromium release so it works
+pretty much like Chrome.
+
+## Usage
+Within Dockerfile:
+
+```
+FROM cucloudcollab/node-puppeteer
+```
+
+Hints for running this container are in https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-in-docker
+In particular, we have found the `--cap-add=SYS_ADMIN` options needs to be specified on the
+Docker run command line.  Otherwise you get sandbox errors.


### PR DESCRIPTION
This adds a docker image including NodeJS:8 and Chrome Headless.  It's perfect for running client tests via Karma or other test runners - the code runs in the latest version of Chrome but without a UI.  Fast and svelte.  Tested on Mac laptop and Jenkins successfully.  