### PR TITLE
Fix travis build errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - docker
 
 before_install:
-    - sudo add-apt-repository ppa:chris-lea/node.js
+    - sudo add-apt-repository -y ppa:chris-lea/node.js
     - sudo apt-get -qq update
     - sudo apt-get install -y nodejs npm
     - sudo npm install -g dockerlint

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - docker
 
 before_install:
-    - sudo add-apt-repository -y ppa:chris-lea/node.js
+    - curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
     - sudo apt-get -qq update
     - sudo apt-get install -y nodejs
     - sudo npm install -g dockerlint

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 before_install:
     - sudo add-apt-repository -y ppa:chris-lea/node.js
     - sudo apt-get -qq update
-    - sudo apt-get install -y nodejs npm
+    - sudo apt-get install -y nodejs
     - sudo npm install -g dockerlint
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ services:
 before_install:
     - sudo apt-get -qq update
     - sudo apt-get install -y nodejs npm
+    - sudo npm install -g npm
     - sudo npm install -g dockerlint
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ services:
   - docker
 
 before_install:
+    - sudo add-apt-repository ppa:chris-lea/node.js
     - sudo apt-get -qq update
     - sudo apt-get install -y nodejs npm
-    - sudo npm install -g npm
     - sudo npm install -g dockerlint
 
 matrix:


### PR DESCRIPTION
Travis was throwing error while installing dockerlint via npm:

```
$ sudo npm install -g dockerlint
npm http GET https://registry.npmjs.org/dockerlint
npm http GET https://registry.npmjs.org/dockerlint
npm http GET https://registry.npmjs.org/dockerlint
npm ERR! Error: CERT_UNTRUSTED
npm ERR!     at SecurePair.<anonymous> (tls.js:1370:32)
npm ERR!     at SecurePair.EventEmitter.emit (events.js:92:17)
npm ERR!     at SecurePair.maybeInitFinished (tls.js:982:10)
npm ERR!     at CleartextStream.read [as _read] (tls.js:469:13)
npm ERR!     at CleartextStream.Readable.read (_stream_readable.js:320:10)
npm ERR!     at EncryptedStream.write [as _write] (tls.js:366:25)
npm ERR!     at doWrite (_stream_writable.js:223:10)
npm ERR!     at writeOrBuffer (_stream_writable.js:213:5)
npm ERR!     at EncryptedStream.Writable.write (_stream_writable.js:180:11)
npm ERR!     at write (_stream_readable.js:583:24)
npm ERR! If you need help, you may report this log at:
npm ERR!     <http://github.com/isaacs/npm/issues>
npm ERR! or email it to:
npm ERR!     <npm-@googlegroups.com>
```

The underlying travis build environment is based on Ubuntu 14.04 which ships with npm 1.3.10 (current generation is 5.x).  

Upgrading resolves the error (using the recommended update procedure for older ubuntu distros (https://nodejs.org/en/download/package-manager/#debian-and-ubuntu-based-linux-distributions).

